### PR TITLE
Roll deps: update errors package

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -75,8 +75,8 @@ func NewParams() *Params {
 		RetryMinWait: time.Second,
 		RetryMaxWait: time.Minute,
 		IsRetriable: func(e error) bool {
-			_, ok := e.(*RetriableError)
-			return ok
+			var re *RetriableError
+			return errors.As(e, &re)
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/smartystreets/goconvey v1.7.2
-	github.com/stockparfait/errors v0.0.3
+	github.com/stockparfait/errors v0.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hgR6gDIPg=
 github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
-github.com/stockparfait/errors v0.0.3 h1:sXK4cx72Mg/1vk9Ra8JJOx+yyFd4vK7fSsX3Tj3iA5Q=
-github.com/stockparfait/errors v0.0.3/go.mod h1:CTvOA0qstSlgAfkHbeCc9DGx3+q++dkXKX3RTsa0S1E=
+github.com/stockparfait/errors v0.0.4 h1:+AkdLE7oa9Kll5AiszDi7hv1cVp33G2ROttF2etzB0Y=
+github.com/stockparfait/errors v0.0.4/go.mod h1:CTvOA0qstSlgAfkHbeCc9DGx3+q++dkXKX3RTsa0S1E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Use the new `As()` method to test for retriable error. This allows a retriable error to be annotated with `errors.Annotate()`, or wrapped by any other error with the `Unwrap()` method, and still be recognized as retriable.

Part of stockparfait/errors#6.